### PR TITLE
modified music during Elite 4

### DIFF
--- a/src/GameEngine.c
+++ b/src/GameEngine.c
@@ -559,6 +559,16 @@ void nextDuel(Window *win, void *data) {
     }
     loadPhrase();
     
+    // Changer la musique si conseil 4
+    if(game.battleState.rouge.nb_enemiBeat>=15){
+        if (game.gameState.music) {
+            Mix_FreeMusic(game.gameState.music);
+            game.gameState.music = NULL;
+            SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO, "✅ Musique libérée");
+        }
+        loadMusic(&game.gameState.music, "assets/audio/conseil_4.mp3");
+    }
+    
     // Changer d'état
     changeState(win, &game.stateHandlers[GAME].state);
 }


### PR DESCRIPTION
## Description
- Qu’est-ce que cette PR change ?
- Quel problème cela résout-il ?
- La musique du conseil 4 est désormais différente de la musique principale de combat.

## Comment tester ?
1. Compiler avec `make rebuild`
2. Exécuter `make run`
3. Vérifier les résultats

## Issue liée
- Closes #123

## Résumé par Sourcery

Modifier la musique de fond pendant le combat contre le Conseil des 4 pour utiliser une piste différente

Nouvelles fonctionnalités :
- Changer la musique de fond pour une piste spécifique lors de l'arrivée au combat contre le Conseil des 4

Améliorations :
- Implémenter une commutation de musique dynamique basée sur la progression du jeu

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify the background music during the Elite 4 battle to use a different track

New Features:
- Change the background music to a specific track when reaching the Elite 4 battle

Enhancements:
- Implement dynamic music switching based on game progression

</details>