### PR TITLE
📊 Enhance entrance animation for ICMon sprites

### DIFF
--- a/data/save/Save_1.txt
+++ b/data/save/Save_1.txt
@@ -2,17 +2,20 @@ User name : SAVE1
 nb:1
 id:29
 lvl:5
-nature:18
-nbmove:1
+nature:13
+nbmove:4
+iv:2
 iv:12
-iv:30
-iv:13
-iv:10
-iv:11
-iv:19
+iv:6
+iv:6
+iv:24
+iv:18
 type:7
-move:22
+move:40
+move:37
+move:27
+move:5
 fichier de save_1
 
 
-Dernier dresseur battu : Baptiste.C id: 1
+Dernier dresseur battu : Logan id: 2

--- a/include/RenderICMons.h
+++ b/include/RenderICMons.h
@@ -37,6 +37,10 @@ typedef struct IMG_ICMons {
     SDL_Texture *nameTexture;        /**< Texture pour le nom de l'ICMons. */
     SDL_Rect nameRect;               /**< Rectangle pour l'affichage du nom. */
     SDL_Rect nameInitialRect;        /**< Rectangle initial pour l'affichage du nom pour les besoins de mise à l'échelle. */
+    // New fields for entrance animation
+    float entranceProgress;  // 0.0 to 1.0
+    int isEntranceAnimating;
+    int isFromRight;  // 1 if entering from right, 0 if from left
 } IMG_ICMons;
 
 /**
@@ -93,5 +97,25 @@ void updateICMonText(t_Poke *poke);
  * @param poke Un pointeur vers la structure t_Poke représentant l'ICMons.
  */
 void destroyICMonsSprite(t_Poke *poke);
+
+/**
+ * @brief Start the entrance animation for an ICMon.
+ * 
+ * This function initializes the entrance animation parameters for an ICMon.
+ * The animation will make the ICMon slide in from either the left or right side.
+ * 
+ * @param poke A pointer to the t_Poke structure representing the ICMon.
+ */
+void startICMonEntranceAnimation(t_Poke *poke);
+
+/**
+ * @brief Update the entrance animation for an ICMon.
+ * 
+ * This function updates the position of the ICMon during its entrance animation.
+ * The ICMon will slide in from either the left or right side.
+ * 
+ * @param poke A pointer to the t_Poke structure representing the ICMon.
+ */
+void updateICMonEntranceAnimation(t_Poke *poke);
 
 #endif

--- a/src/Events.c
+++ b/src/Events.c
@@ -49,6 +49,11 @@ int initTeamSprites(Window *win, t_Team *teamSprite, float x_ratio, float y_rati
                 "❌ Failed to initialize sprite for %s team pokemon %d", (teamFlag == 0 ? "red" : "blue"), i);
             return -1;
         }
+        
+        // Start entrance animation only for the first Pokemon of each team
+        if (i == 0) {
+            startICMonEntranceAnimation(poke);
+        }
     }
     return 0;
 }

--- a/src/RenderICMons.c
+++ b/src/RenderICMons.c
@@ -116,6 +116,11 @@ IMG_ICMons *initICMonSprite(SDL_Renderer *renderer, SDL_Rect spriteRect, SDL_Rec
     }
     
     img->renderer = renderer;
+    // Initialize animation fields
+    img->entranceProgress = 0.0f;
+    img->isEntranceAnimating = 0;
+    img->isFromRight = (team == 0);  // Player's ICMon enters from right
+    
     // Construction du chemin de l'image
     char path[128];
     snprintf(path, sizeof(path), "assets/Monsters/New Versions/%s.png", poke->name);
@@ -222,6 +227,52 @@ static void updatePVBar(t_Poke *poke) {
     SDL_RenderFillRect(poke->img->renderer, &pvForeground);
 }
 
+/**
+ * @brief Start the entrance animation for an ICMon.
+ *
+ * This function initializes the entrance animation parameters for an ICMon.
+ * The animation will make the ICMon slide in from either the left or right side.
+ *
+ * @param poke The ICMon to animate.
+ */
+void startICMonEntranceAnimation(t_Poke *poke) {
+    if (!poke || !poke->img) return;
+    
+    poke->img->entranceProgress = 0.0f;
+    poke->img->isEntranceAnimating = 1;
+}
+
+/**
+ * @brief Update the entrance animation for an ICMon.
+ *
+ * This function updates the position of the ICMon during its entrance animation.
+ * The ICMon will slide in from either the left or right side.
+ *
+ * @param poke The ICMon being animated.
+ */
+void updateICMonEntranceAnimation(t_Poke *poke) {
+    if (!poke || !poke->img || !poke->img->isEntranceAnimating) return;
+    
+    float targetX = poke->img->initialRect.x;
+    float startX = poke->img->isFromRight ? 
+                  targetX + poke->img->initialRect.w * 2 : 
+                  targetX - poke->img->initialRect.w * 2;
+    
+    // Update progress
+    poke->img->entranceProgress += 0.025f;  // Adjust speed as needed
+    if (poke->img->entranceProgress > 1.0f) {
+        poke->img->entranceProgress = 1.0f;
+        poke->img->isEntranceAnimating = 0;
+    }
+    
+    // Calculate current position using easing
+    float t = poke->img->entranceProgress;
+    t = 1.0f - (1.0f - t) * (1.0f - t);  // Ease out quad
+    float currentX = startX + (targetX - startX) * t;
+    
+    // Update position
+    poke->img->rect.x = (int)currentX;
+}
 
 /**
  * @brief Rendu du sprite ICMon sur la fenêtre.
@@ -234,6 +285,9 @@ static void updatePVBar(t_Poke *poke) {
  */
 void renderICMonsSprite(Window *win, t_Poke *poke) {
     if (!poke || !poke->img) return;
+    
+    // Update entrance animation if active
+    updateICMonEntranceAnimation(poke);
     
     // Mise à jour du texte de PV avec les valeurs actuelles
     static char pvBuffer[32];


### PR DESCRIPTION
## Description
- Ajout des animations d'entrée de combat

## Comment tester ?
1. Compiler avec `make rebuild`
2. Exécuter `make run`
3. Vérifier les résultats

## Issue liée
- Closes #35

## Résumé par Sourcery

Ajout d'une animation d'entrée pour les sprites ICMon pendant l'initialisation du combat

Nouvelles fonctionnalités :
- Implémentation d'une animation d'entrée coulissante pour les sprites ICMon lors de l'entrée en combat, avec prise en charge de l'entrée depuis les côtés gauche ou droit

Améliorations :
- Ajout d'une animation d'atténuation fluide pour l'entrée des sprites ICMon
- Introduction du suivi de la progression de l'animation pour le mouvement des sprites

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add entrance animation for ICMon sprites during battle initialization

New Features:
- Implement a sliding entrance animation for ICMon sprites when entering battle, with support for entering from left or right sides

Enhancements:
- Add smooth easing animation for ICMon sprite entrance
- Introduce animation progress tracking for sprite movement

</details>