### PR TITLE
41 swapping gamestate is pure chaos

### DIFF
--- a/include/GameEngine.h
+++ b/include/GameEngine.h
@@ -119,10 +119,11 @@ typedef struct Game {
     ThreadManager threadManager; /**< Gestionnaire de threads. */
     SDL_Surface *cursor;       /**< Surface du curseur. */
     SDL_Surface *cursor_hover; /**< Surface du curseur au survol. */
-    int swappingIndex[2];
-    Text * windowText;
-    t_Poke starters[4];
-    int startersIndex;
+    int swappingIndex[2];       /**< Indices des ICMons cible de l'échange */
+    int hasExchanged;           /**< Booleen "si echange disponible" */
+    Text * windowText;          /**< Conteneur de texte pour une fenêtre quelconque*/
+    t_Poke starters[4];         /**< Les quatres ICMon disponibles au début du jeu */
+    int startersIndex;          /**< Indice du starter choisi*/
     Image **touche;
     ScrollingText *scrollingTextIntro;
     

--- a/src/GameEngine.c
+++ b/src/GameEngine.c
@@ -547,7 +547,6 @@ void nextDuel(Window *win, void *data) {
     healTeam(&game.battleState.rouge);
     initBlueTeam(&game.battleState.bleu, &game.battleState.rouge);
     game.battleState.rouge.nb_enemiBeat++;
-    printf("%d\n",game.battleState.rouge.nb_enemiBeat);
     
     // Réinitialiser l'IA
     game.battleState.ia = (t_AI){10, damageOnly, &game.battleState.bleu};

--- a/src/duel.c
+++ b/src/duel.c
@@ -258,7 +258,7 @@ void initBlueTeam(t_Team *t,t_Team *joueur) {
     } else {
         char buffer[256];
 		//nombre random entre 1 et 8
-		int id = 1+2*joueur->nb_enemiBeat+rand()%2;
+		int id = 2*joueur->nb_enemiBeat+rand()%2+1;
         for (int i = 1; i < id; i++) {
             if (fgets(buffer, sizeof(buffer), fichierTrainer) == NULL) {
                 printf("Erreur : ligne %d introuvable dans le fichier.\n", id);


### PR DESCRIPTION
## Description
- Qu’est-ce que cette PR change ?
- Quel problème cela résout-il ?
- No more infinite ICMon swapping
- Game successfully save after a swap
- Fixed wrong trainer being loaded
- Variable name "nbmili" changed for better understanding

## Comment tester ?
1. Compiler avec `make rebuild`
2. Exécuter `make run`
3. Vérifier les résultats

## Issue liée
- Closes #123

## Résumé par Sourcery

Amélioration de la gestion de l'état du jeu et des mécanismes d'échange d'équipe pour empêcher les échanges infinis et assurer une progression correcte du jeu.

Nouvelles fonctionnalités :
- Implémentation d'un mécanisme pour empêcher les échanges d'équipe multiples dans un seul duel

Corrections de bugs :
- Empêcher l'échange infini d'ICMon en ajoutant un drapeau pour suivre les échanges
- S'assurer que l'état du jeu est correctement sauvegardé après l'échange d'équipe
- Correction de la logique de chargement des dresseurs pour sélectionner correctement les dresseurs adverses

Améliorations :
- Modification de la fonction de validation du temps pour utiliser les microsecondes au lieu des millisecondes
- Ajout d'un drapeau pour suivre si un échange d'équipe a eu lieu

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve game state management and team swapping mechanics to prevent infinite exchanges and ensure proper game progression

New Features:
- Implement a mechanism to prevent multiple team exchanges in a single duel

Bug Fixes:
- Prevent infinite ICMon swapping by adding a flag to track exchanges
- Ensure game state is correctly saved after team swapping
- Fix trainer loading logic to correctly select opponent trainers

Enhancements:
- Modify time validation function to use microseconds instead of milliseconds
- Add a flag to track whether a team exchange has occurred

</details>