### PR TITLE
Guys it's fixed

### DIFF
--- a/src/GameEngine.c
+++ b/src/GameEngine.c
@@ -403,6 +403,10 @@ void validateStarterChoice(Window *win, void *data){
         
     updateICButtons(win, &game.battleState.rouge);
     setDefaultStatChanges(&game.battleState.rouge);
+
+    for(int i=0;i<4;i++){
+        if(i!=game.startersIndex && game.starters[i].img) destroyICMonsSprite(&game.starters[i]);
+    }
         
     game.gameState.initialized = 1;
     changeState(win,&game.stateHandlers[MAP].state);
@@ -546,11 +550,14 @@ void nextDuel(Window *win, void *data) {
     // Soigner et réinitialiser
     healTeam(&game.battleState.rouge);
     initBlueTeam(&game.battleState.bleu, &game.battleState.rouge);
-    game.battleState.rouge.nb_enemiBeat++;
     
     // Réinitialiser l'IA
-    game.battleState.ia = (t_AI){10, damageOnly, &game.battleState.bleu};
+    //game.battleState.ia = (t_AI){10, damageOnly, &game.battleState.bleu};
+    game.battleState.ia.AI_lvl = 1 + game.battleState.rouge.nb_enemiBeat;
+    game.battleState.ia.type = 2 + rand()%2;
+    if(game.battleState.rouge.nb_enemiBeat>=15) game.battleState.ia.type = boss;
     
+    game.battleState.rouge.nb_enemiBeat++;
     // Initialiser les sprites avec vérification d'erreur
     if (initTeamSprites(win, &game.battleState.bleu, BLUE_SPRITE_X_RATIO, BLUE_SPRITE_Y_RATIO, 1) != 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Erreur lors de l'initialisation des sprites");
@@ -1210,19 +1217,21 @@ void updateBattleTurn() {
                 }
                 game.battleState.hasAttacked = true;
             }
-            if(game.battleState.hasAttacked && game.battleState.text->isComplete && criticalHitFlag){
-                char msg[60];
-                sprintf(msg,"Coup critique !");
-                criticalHitFlag=0;
-                resetScrollingText(game.battleState.text, msg);
-            }
-            if(game.battleState.hasAttacked && game.battleState.text->isComplete && !(moveEffectivenessFlag<-1)){
-                char msg[60]="\0";
-                if(moveEffectivenessFlag==0) sprintf(msg,"Cela n'a aucun effet !");
-                else if(moveEffectivenessFlag<=0.9) sprintf(msg,"Ce n'est pas très efficace !");
-                else if(moveEffectivenessFlag>1.1) sprintf(msg,"C'est super efficace !");
-                moveEffectivenessFlag=-2;
-                if(msg[0]!='\0') resetScrollingText(game.battleState.text, msg);
+            if((game.battleState.first && isAttacking(game.battleState.moveRouge)) || (!game.battleState.first && isAttacking(game.battleState.moveBleu))){
+                if(game.battleState.hasAttacked && game.battleState.text->isComplete && criticalHitFlag){
+                    char msg[60];
+                    sprintf(msg,"Coup critique !");
+                    criticalHitFlag=0;
+                    resetScrollingText(game.battleState.text, msg);
+                }
+                if(game.battleState.hasAttacked && game.battleState.text->isComplete && !(moveEffectivenessFlag<-1)){
+                    char msg[60]="\0";
+                    if(moveEffectivenessFlag==0) sprintf(msg,"Cela n'a aucun effet !");
+                    else if(moveEffectivenessFlag<=0.9) sprintf(msg,"Ce n'est pas très efficace !");
+                    else if(moveEffectivenessFlag>1.1) sprintf(msg,"C'est super efficace !");
+                    moveEffectivenessFlag=-2;
+                    if(msg[0]!='\0') resetScrollingText(game.battleState.text, msg);
+                }
             }
             if (game.battleState.text->isComplete) {
                 game.battleState.text->isComplete = false;
@@ -1261,19 +1270,21 @@ void updateBattleTurn() {
                 }
                 game.battleState.hasAttacked = true;
             }
-            if(game.battleState.hasAttacked && game.battleState.text->isComplete && criticalHitFlag){
-                char msg[60];
-                sprintf(msg,"Coup critique !");
-                criticalHitFlag=0;
-                resetScrollingText(game.battleState.text, msg);
-            }
-            if(game.battleState.hasAttacked && game.battleState.text->isComplete && !(moveEffectivenessFlag<-1)){
-                char msg[60]="\0";
-                if(moveEffectivenessFlag==0) sprintf(msg,"Cela n'a aucun effet !");
-                else if(moveEffectivenessFlag<=0.9) sprintf(msg,"Ce n'est pas très efficace !");
-                else if(moveEffectivenessFlag>1.1) sprintf(msg,"C'est super efficace !");
-                moveEffectivenessFlag=-2;
-                if(msg[0]!='\0') resetScrollingText(game.battleState.text, msg);
+            if((game.battleState.first && isAttacking(game.battleState.moveBleu)) || (!game.battleState.first && isAttacking(game.battleState.moveRouge))){
+                if(game.battleState.hasAttacked && game.battleState.text->isComplete && criticalHitFlag){
+                    char msg[60];
+                    sprintf(msg,"Coup critique !");
+                    criticalHitFlag=0;
+                    resetScrollingText(game.battleState.text, msg);
+                }
+                if(game.battleState.hasAttacked && game.battleState.text->isComplete && !(moveEffectivenessFlag<-1)){
+                    char msg[60]="\0";
+                    if(moveEffectivenessFlag==0) sprintf(msg,"Cela n'a aucun effet !");
+                    else if(moveEffectivenessFlag<=0.9) sprintf(msg,"Ce n'est pas très efficace !");
+                    else if(moveEffectivenessFlag>1.1) sprintf(msg,"C'est super efficace !");
+                    moveEffectivenessFlag=-2;
+                    if(msg[0]!='\0') resetScrollingText(game.battleState.text, msg);
+                }
             }
             if (game.battleState.text->isComplete) {
                 game.battleState.text->isComplete = false;

--- a/src/duel.c
+++ b/src/duel.c
@@ -522,7 +522,7 @@ int affectDamage(t_Team * offender, t_Team * defender, int indexMove){
 	//printf("Dégats = %d\n",damage);
 	defender->team[0].current_pv=defender->team[0].current_pv>damage?(int)(defender->team[0].current_pv - damage):0;
 	if (!(indexMove<0)) (moveToDo->current_pp)--;
-	launchSecEffect(offender,defender,moveToDo);
+	if (moveEffectivenessFlag!=0) launchSecEffect(offender,defender,moveToDo);
 	return TRUE;
 }
 


### PR DESCRIPTION
## Description
- Qu’est-ce que cette PR change ?
- Quel problème cela résout-il ?
- Les boites de textes sont désormais toutes jouées dans des timings où elles font sens.
- Les effets d'attaques ne se lancent que si l'attaque affecte l'opposant.
- L'ia devient de plus en plus forte à mesure des combats.
- Une fuite mémoire à été fixée sur l'écran des starters.

## Comment tester ?
1. Compiler avec `make rebuild`
2. Exécuter `make run`
3. Vérifier les résultats

## Issue liée
- Closes #123

## Résumé par Sourcery

Amélioration des mécanismes de combat du jeu et correction des problèmes liés à la mémoire dans le moteur du jeu

Corrections de bugs :
- Correction d'une fuite de mémoire sur l'écran des starters en détruisant les sprites de starter inutilisés
- Empêcher les effets d'attaque secondaire de se déclencher lorsqu'un mouvement n'a aucun effet
- S'assurer que les boîtes de texte ne s'affichent que lorsque cela est approprié pendant la bataille

Améliorations :
- Améliorer la progression de la difficulté de l'IA en augmentant la complexité à chaque bataille
- Améliorer la messagerie de l'efficacité des attaques
- Ajouter une sélection de comportement d'IA plus dynamique

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve game battle mechanics and fix memory-related issues in the game engine

Bug Fixes:
- Fix memory leak on the starters screen by destroying unused starter sprites
- Prevent secondary attack effects from triggering when a move has no effect
- Ensure text boxes are displayed only when appropriate during battle

Enhancements:
- Enhance AI difficulty progression by increasing complexity with each battle
- Improve attack effectiveness messaging
- Add more dynamic AI behavior selection

</details>