### PR TITLE
Test windows build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.zip filter=lfs diff=lfs merge=lfs -text
 *.tar.gz filter=lfs diff=lfs merge=lfs -text
 ICPocket-linux.zip filter=lfs diff=lfs merge=lfs -text
+ICPocket-windows.zip filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -130,7 +130,7 @@ jobs:
         
         git add .gitattributes
         git commit -m "📦 Windows build $(date -u +%Y-%m-%d)"
-        git push origin main --force
+        git push --force
 
     - name: Upload to Artifacts
       if: env.HAS_COMMITS == 'true'

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,6 +1,8 @@
 name: Windows Build at Midnight
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -27,8 +29,21 @@ jobs:
         git lfs install
         git lfs track "*.zip"
         git add .gitattributes
-    - name: Setup MSYS2
 
+    - name: Check for today's commits
+      id: check_commits
+      shell: bash
+      run: |
+        TODAY=$(date -u +%Y-%m-%d)
+        COMMITS_TODAY=$(git log --since="$TODAY 00:00:00" --until="$TODAY 23:59:59" --oneline)
+        if [ -n "$COMMITS_TODAY" ]; then
+          echo "HAS_COMMITS=true" >> $GITHUB_ENV
+        else
+          echo "HAS_COMMITS=false" >> $GITHUB_ENV
+        fi
+
+    - name: Setup MSYS2
+      if: env.HAS_COMMITS == 'true'
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
@@ -41,15 +56,14 @@ jobs:
           mingw-w64-x86_64-SDL2_ttf
           zip
           make
+
     - name: Build
+      if: env.HAS_COMMITS == 'true'
       shell: msys2 {0}
       run: |
         mkdir -p bin/windows
         
-        if [ -f "Makefile" ]; then
-          make package-windows
-        else
-          gcc -o bin/windows/${{ env.PROJECT_NAME }}.exe \
+        gcc -o bin/windows/${{ env.PROJECT_NAME }}.exe \
             main.c src/*.c \
             -I./include \
             -I/mingw64/include/SDL2 \
@@ -57,8 +71,9 @@ jobs:
             -lmingw32 -lSDL2main -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf \
             -mwindows \
             -O2
-        fi
+
     - name: Package
+      if: env.HAS_COMMITS == 'true'
       shell: msys2 {0}
       run: |
         DLLS=(
@@ -86,7 +101,9 @@ jobs:
         cd bin
         zip -9 -r ../${{ env.PROJECT_NAME }}-windows.zip windows/ ../assets/ ../data/ ../README.md
         cd ..
+
     - name: Split ZIP if needed
+      if: env.HAS_COMMITS == 'true'
       shell: bash
       run: |
         ZIP_SIZE=$(stat -f %z "${{ env.PROJECT_NAME }}-windows.zip" 2>/dev/null || stat -c %s "${{ env.PROJECT_NAME }}-windows.zip")
@@ -94,7 +111,9 @@ jobs:
           echo "Splitting ZIP file..."
           split -b 95m "${{ env.PROJECT_NAME }}-windows.zip" "${{ env.PROJECT_NAME }}-windows.zip.part"
         fi
+
     - name: Commit and Push
+      if: env.HAS_COMMITS == 'true'
       shell: bash
       run: |
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -114,7 +133,9 @@ jobs:
         git add .gitattributes
         git commit -m "📦 Windows build $(date -u +%Y-%m-%d)"
         git push origin main --force
+
     - name: Upload to Artifacts
+      if: env.HAS_COMMITS == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.PROJECT_NAME }}-Windows
@@ -122,6 +143,7 @@ jobs:
         retention-days: 5
 
     - name: Cleanup
+      if: always()
       shell: bash
       run: |
         rm -rf bin/

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,8 +1,6 @@
 name: Windows Build at Midnight
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
@@ -62,7 +60,7 @@ jobs:
       shell: msys2 {0}
       run: |
         mkdir -p bin/windows
-        
+
         gcc -o bin/windows/${{ env.PROJECT_NAME }}.exe \
             main.c src/*.c \
             -I./include \

--- a/ICPocket-windows.zip
+++ b/ICPocket-windows.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c0b247ef6d7b1f639b29720d2b11ad2bf36266e30388a84cac9f786eb58c297
+size 13793923

--- a/src/duel.c
+++ b/src/duel.c
@@ -172,7 +172,7 @@ void teamTest(t_Team * t, int nb_poke){
 		t->team[i].lvl=50;
 		t->team[i].nature=0;
 		t->team[i].type[0]=plante;
-		for(int j=0;j<7;j++){
+		for(int j=0;j<6;j++){
 			t->team[i].baseStats[j]=100;
 		}
 		for(int j=0;j<6;j++){

--- a/src/save.c
+++ b/src/save.c
@@ -18,7 +18,11 @@ void sauvegarder(t_Team * joueur,t_Team * adverse){
     FILE *fichier = fopen(nomFichier, "w+");
     if(fichier == NULL){
         char * path = "data/save";
-        mkdir(path, 0777);
+        #ifdef _WIN32
+            mkdir(path);
+        #else
+            mkdir(path, 0777);
+        #endif
         fichier = fopen(nomFichier, "w+");
         sauver(joueur,1,nomFichier);
     } else {


### PR DESCRIPTION
## Description
- Corrige le build windows.

## Comment tester ?

1. Aller dans github actions
2. lancer le build windows

## Résumé par Sourcery

Amélioration du flux de travail de construction Windows et de la compatibilité

Corrections de bugs :
- Correction de l'appel mkdir spécifique à Windows dans la fonctionnalité de sauvegarde
- Ajustement de l'itération du tableau dans la fonction teamTest pour éviter un potentiel accès hors limites

Améliorations :
- Optimisation du processus de construction Windows pour qu'il ne s'exécute que lorsque de nouveaux commits sont présents
- Ajout d'une gestion des erreurs plus robuste et d'une exécution conditionnelle dans le flux de travail de construction

CI :
- Ajout d'étapes de construction conditionnelles qui ne s'exécutent que lorsqu'il y a des commits pour la journée
- Modification du workflow GitHub Actions pour gérer les exigences de construction spécifiques à Windows

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Windows build workflow and compatibility

Bug Fixes:
- Fix Windows-specific mkdir call in save functionality
- Adjust array iteration in teamTest function to prevent potential out-of-bounds access

Enhancements:
- Optimize Windows build process to only run when new commits are present
- Add more robust error handling and conditional execution in build workflow

CI:
- Add conditional build steps that only run when there are commits for the day
- Modify GitHub Actions workflow to handle Windows-specific build requirements

</details>